### PR TITLE
feat(theme): add theme toggle and multi-theme support

### DIFF
--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -57,6 +57,7 @@ jobs:
           # npm install recharts && \
           # npm install lucide-react && \
           # npm run build && \
+          npm install && \
           bundle install && bundle exec jekyll build --baseurl "${{ steps.pages.outputs.base_path }}"
         env:
           JEKYLL_ENV: production

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ Gemfile.lock
 .jekyll-metadata
 
 .qodo
+/node_modules/

--- a/Gemfile
+++ b/Gemfile
@@ -38,3 +38,5 @@ group :development do
   gem 'ruby-lsp'
   gem 'solargraph'
 end
+
+gem "jekyll-postcss", "~> 0.5.0"

--- a/_config.yml
+++ b/_config.yml
@@ -40,7 +40,7 @@ twitter:
 linkedin: robert-william-pannick-260492176
 support: https://github.com/b08x/b08x.github.io/issues
 repo: https://github.com/b08x/b08x.github.io
-github_user: "b08x"
+github_user: b08x
 github_repo: "b08x.github.io"
 # discord: https://community.discord.com
 
@@ -67,8 +67,11 @@ themeColor: red # purple, green, blue, orange, purple, grey
 fixedNav: 'true' # true or false
 
 permalink: /:year/:title/
-markdown: kramdown
+
 exclude: [_site, CHANGELOG.md, LICENSE, README.md, vendor]
+
+plugins:
+  - jekyll-postcss-v2
 
 # Collections
 collections:

--- a/_data/theme.yml
+++ b/_data/theme.yml
@@ -1,0 +1,87 @@
+# Theme Configuration for Dark/Light Mode Support
+
+themes:
+  light:
+    name: "Light"
+    icon: "☀️"
+    colors:
+      # Background colors
+      bg_primary: "#ffffff"
+      bg_secondary: "#f8f9fa"
+      bg_tertiary: "#f1f3f4"
+      
+      # Text colors
+      text_primary: "#1e293b"     # navy equivalent for dark text
+      text_secondary: "#64748b"   # gray-600 equivalent
+      text_tertiary: "#94a3b8"    # gray-400 equivalent
+      text_muted: "#cbd5e1"       # gray-300 equivalent
+      
+      # Border and accent colors
+      border_primary: "#e2e8f0"   # gray-200 equivalent
+      border_secondary: "#cbd5e1" # gray-300 equivalent
+      accent_primary: "#8b5cf6"   # violet-500 for links and accents
+      accent_hover: "#7c3aed"     # violet-600 for hover states
+      
+      # Header specific
+      header_bg: "#ffffff"
+      header_text: "#1e293b"
+      header_border: "rgba(0, 0, 0, 0.1)"
+      
+      # Sidebar specific
+      sidebar_bg: "#ffffff"
+      sidebar_text: "#1e293b"
+      
+      # Code and syntax highlighting
+      code_bg: "#f1f5f9"
+      code_text: "#334155"
+      
+  dark:
+    name: "Dark"
+    icon: "🌙"
+    colors:
+      # Background colors
+      bg_primary: "#0f172a"       # slate-900
+      bg_secondary: "#1e293b"     # slate-800
+      bg_tertiary: "#334155"      # slate-700
+      
+      # Text colors
+      text_primary: "#f8fafc"     # slate-50
+      text_secondary: "#cbd5e1"   # slate-300
+      text_tertiary: "#94a3b8"    # slate-400
+      text_muted: "#64748b"       # slate-500
+      
+      # Border and accent colors
+      border_primary: "#334155"   # slate-700
+      border_secondary: "#475569" # slate-600
+      accent_primary: "#a78bfa"   # violet-400 (lighter for dark theme)
+      accent_hover: "#8b5cf6"     # violet-500 for hover
+      
+      # Header specific
+      header_bg: "#1e293b"
+      header_text: "#f8fafc"
+      header_border: "rgba(255, 255, 255, 0.1)"
+      
+      # Sidebar specific
+      sidebar_bg: "#1e293b"
+      sidebar_text: "#f8fafc"
+      
+      # Code and syntax highlighting
+      code_bg: "#334155"
+      code_text: "#e2e8f0"
+      
+  auto:
+    name: "Auto"
+    icon: "🔄"
+    description: "Follow system preference"
+
+# Default theme (used when no preference is stored)
+default_theme: "light"
+
+# Enable automatic system theme detection
+enable_system_theme: true
+
+# Theme transition duration (CSS)
+transition_duration: "0.3s"
+
+# Enable theme persistence in localStorage
+enable_persistence: true

--- a/_docs/getting-started.md
+++ b/_docs/getting-started.md
@@ -4,8 +4,8 @@ tags:
  - github
 description: Getting started with Tw-Jekyll
 author:
-  name: Vanessa Sochat
-  github: vsoch
+  name: Robert Pannick
+  github: b08x
 ---
 
 ## Features
@@ -358,7 +358,6 @@ https://<circleci>/0/tw-jekyll/docs/getting-started/index.html
 
 To edit configuration values, customize the [_config.yml](_config.yml). There are a lot
 of small details that are included there that are not mentioned here!
-Please [open an issue](<https://www.github.com/{{> site.github_user }}/{{ site.github_user }}/issues) if you have questions.
 
 #### Adding pages
 

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -39,6 +39,40 @@
 <meta property="og:type" content=article>
 {% if site.logo %}<meta property="og:image" content="{{ site.baseurl }}{{ site.logo }}">{% endif %}
 
+<!-- FOUC Prevention: Apply stored theme immediately -->
+<script>
+(function() {
+  'use strict';
+  
+  // Get stored theme or use default
+  function getStoredTheme() {
+    try {
+      return localStorage.getItem('theme') || '{{ site.data.theme.default_theme }}';
+    } catch (e) {
+      return '{{ site.data.theme.default_theme }}';
+    }
+  }
+  
+  // Get system theme preference
+  function getSystemTheme() {
+    {% if site.data.theme.enable_system_theme %}
+    try {
+      return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+    } catch (e) {
+      return 'light';
+    }
+    {% else %}
+    return 'light';
+    {% endif %}
+  }
+  
+  // Apply theme immediately
+  const storedTheme = getStoredTheme();
+  const resolvedTheme = storedTheme === 'auto' ? getSystemTheme() : storedTheme;
+  document.documentElement.setAttribute('data-theme', resolvedTheme);
+})();
+</script>
+
 <style>@font-face{font-family:'Inter';src:url({{ site.baseurl }}/assets/fonts/inter-light.woff2)format('woff2');font-weight:300;font-style:normal;}@font-face{font-family:'Inter';src:url({{ site.baseurl }}/assets/fonts/inter-regular.woff2)format('woff2');font-weight:400;font-style:normal;}@font-face{font-family:'Inter';src:url({{ site.baseurl }}/assets/fonts/inter-medium.woff2)format('woff2');font-weight:500;font-style:normal;}@font-face{font-family:'Inter';src:url({{ site.baseurl }}/assets/fonts/inter-semibold.woff2)format('woff2');font-weight:600;font-style:normal;}@font-face{font-family:'Inter';src:url({{ site.baseurl }}/assets/fonts/inter-bold.woff2)format('woff2');font-weight:700;font-style:normal;}@font-face{font-family:'Mackinac';src:url({{ site.baseurl }}/assets/fonts/mackinac-bold.woff2)format('woff2');font-weight:700;font-style:normal;}@font-face{font-family:'Native';src:url({{ site.baseurl }}/assets/fonts/native-regular.woff2)format('woff2');font-weight:400;font-style:normal;}@font-face{font-family:'Native';src:url({{ site.baseurl }}/assets/fonts/native-bold.woff2)format('woff2');font-weight:700;font-style:normal;}</style>
       <script>var fontsInServiceWorker=sessionStorage.foutFontsStage1Loaded&&sessionStorage.foutFontsStage2Loaded||"serviceWorker"in navigator&&null!==navigator.serviceWorker.controller&&"activated"===navigator.serviceWorker.controller.state;if(!fontsInServiceWorker&&"fonts"in document){function fetchFonts(o){return Promise.all(o.map(function(o){return document.fonts.load(o)}))}sessionStorage.foutFontsStage2Loaded?document.documentElement.className+=" wf-loaded-stage2":sessionStorage.foutFontsStage1Loaded=!0}if("fonts"in document){let o=new FontFace("Inter","url({{ site.baseurl }}/assets/fonts/inter-light.woff2) format('woff2')",{weight:"300"}),e=new FontFace("Inter","url({{ site.baseurl }}/assets/fonts/inter-regular.woff2) format('woff2')",{weight:"400"}),t=new FontFace("Inter","url({{ site.baseurl }}/assets/fonts/inter-medium.woff2) format('woff2')",{weight:"500"}),n=new FontFace("Inter","url({{ site.baseurl }}/assets/fonts/inter-semibold.woff2) format('woff2')",{weight:"600"}),a=new FontFace("Inter","url({{ site.baseurl }}/assets/fonts/inter-bold.woff2) format('woff2')",{weight:"700"}),r=new FontFace("Mackinac","url({{ site.baseurl }}/assets/fonts/mackinac-bold.woff2) format('woff2')",{weight:"700"}),f=new FontFace("Native","url({{ site.baseurl }}/assets/fonts/native-regular.woff2) format('woff2')",{weight:"400"}),i=new FontFace("Native","url({{ site.baseurl }}/assets/fonts/native-bold.woff2) format('woff2')",{weight:"700"});Promise.all([o.load(),e.load(),t.load(),n.load(),a.load(),r.load(),f.load(),i.load()]).then(o=>{o.forEach(o=>document.fonts.add(o)),document.documentElement.classList.add("wf-loaded-stage2"),sessionStorage.foutFontsStage2Loaded=!0}).catch(o=>{throw new Error(`Error caught: ${o}`)})}(sessionStorage.foutFontsStage1Loaded&&sessionStorage.foutFontsStage2Loaded||"serviceWorker"in navigator&&null!==navigator.serviceWorker.controller&&"activated"===navigator.serviceWorker.controller.state)&&document.documentElement.classList.add("wf-loaded-stage2");</script>
 <link rel=preload href="{{ site.baseurl }}/assets/fonts/inter-light.woff2" as=font type="font/woff2" crossorigin>
@@ -50,6 +84,7 @@
 <link rel=preload href="{{ site.baseurl }}/assets/fonts/native-regular.woff2" as=font type="font/woff2" crossorigin>
 <link rel=preload href="{{ site.baseurl }}/assets/fonts/native-bold.woff2" as=font type="font/woff2" crossorigin>
 <link rel=stylesheet href="{{ site.baseurl }}/assets/css/tailwind.css" media=all>
+<link rel=stylesheet href="{{ site.baseurl }}/assets/css/themes.css" media=all>
 <link rel=stylesheet href="{{ site.baseurl }}/assets/css/main.css" media=all>
 <link rel=stylesheet href="{{ site.baseurl }}/assets/css/docsearch.css" media=all>
 </head>

--- a/_includes/theme-toggle.html
+++ b/_includes/theme-toggle.html
@@ -1,0 +1,220 @@
+<!-- Theme Toggle Component -->
+<div class="theme-toggle">
+  <!-- Button toggle for cycling through themes -->
+  <button 
+    id="theme-toggle" 
+    class="theme-toggle__button" 
+    aria-label="Toggle theme"
+    title="Toggle between light, dark, and auto themes"
+    type="button"
+  >
+    {% for theme in site.data.theme.themes %}
+    {% assign theme_name = theme[0] %}
+    {% assign theme_data = theme[1] %}
+    {% if theme_data.icon %}
+    <span 
+      class="theme-toggle__icon" 
+      data-theme="{{ theme_name }}"
+      aria-hidden="true"
+    >{{ theme_data.icon }}</span>
+    {% endif %}
+    {% endfor %}
+  </button>
+  
+  <!-- Optional dropdown select for accessibility -->
+  <select 
+    id="theme-select" 
+    class="theme-toggle__select sr-only md:not-sr-only" 
+    aria-label="Select theme"
+    title="Choose your preferred theme"
+  >
+    {% for theme in site.data.theme.themes %}
+    {% assign theme_name = theme[0] %}
+    {% assign theme_data = theme[1] %}
+    <option value="{{ theme_name }}">
+      {{ theme_data.name }}{% if theme_data.description %} - {{ theme_data.description }}{% endif %}
+    </option>
+    {% endfor %}
+  </select>
+</div>
+
+<!-- Theme management script -->
+<script>
+(function() {
+  'use strict';
+  
+  class ThemeManager {
+    constructor() {
+      this.themes = {{ site.data.theme.themes | jsonify }};
+      this.defaultTheme = '{{ site.data.theme.default_theme }}';
+      this.systemThemeEnabled = {{ site.data.theme.enable_system_theme | jsonify }};
+      this.persistenceEnabled = {{ site.data.theme.enable_persistence | jsonify }};
+      
+      this.currentTheme = this.getStoredTheme() || this.defaultTheme;
+      this.init();
+    }
+
+    init() {
+      this.applyTheme(this.currentTheme);
+      this.bindEvents();
+      this.updateToggleUI();
+    }
+
+    getStoredTheme() {
+      if (!this.persistenceEnabled) return null;
+      try {
+        return localStorage.getItem('theme');
+      } catch (e) {
+        console.warn('ThemeManager: Unable to access localStorage');
+        return null;
+      }
+    }
+
+    setStoredTheme(theme) {
+      if (!this.persistenceEnabled) return;
+      try {
+        localStorage.setItem('theme', theme);
+      } catch (e) {
+        console.warn('ThemeManager: Unable to save theme preference');
+      }
+    }
+
+    getSystemTheme() {
+      if (!this.systemThemeEnabled) return this.defaultTheme;
+      try {
+        return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+      } catch (e) {
+        return this.defaultTheme;
+      }
+    }
+
+    applyTheme(theme) {
+      const resolvedTheme = theme === 'auto' ? this.getSystemTheme() : theme;
+      
+      // Apply theme to document
+      document.documentElement.setAttribute('data-theme', resolvedTheme);
+      
+      // Update meta theme-color for mobile browsers
+      this.updateThemeColor(resolvedTheme);
+      
+      this.currentTheme = theme;
+      this.setStoredTheme(theme);
+      
+      // Dispatch custom event for other scripts
+      window.dispatchEvent(new CustomEvent('themeChanged', {
+        detail: { theme: theme, resolvedTheme: resolvedTheme }
+      }));
+    }
+
+    updateThemeColor(resolvedTheme) {
+      const metaThemeColor = document.querySelector('meta[name="theme-color"]');
+      if (metaThemeColor && this.themes[resolvedTheme]) {
+        const themeColors = this.themes[resolvedTheme].colors;
+        if (themeColors && themeColors.header_bg) {
+          metaThemeColor.setAttribute('content', themeColors.header_bg);
+        }
+      }
+    }
+
+    toggleTheme() {
+      const themeKeys = Object.keys(this.themes);
+      const currentIndex = themeKeys.indexOf(this.currentTheme);
+      const nextTheme = themeKeys[(currentIndex + 1) % themeKeys.length];
+      
+      this.applyTheme(nextTheme);
+      this.updateToggleUI();
+    }
+
+    updateToggleUI() {
+      const button = document.getElementById('theme-toggle');
+      const select = document.getElementById('theme-select');
+      
+      if (button) {
+        // Hide all icons
+        const icons = button.querySelectorAll('.theme-toggle__icon');
+        icons.forEach(icon => {
+          icon.style.display = 'none';
+          icon.classList.remove('active');
+        });
+        
+        // Show current theme icon
+        const activeIcon = button.querySelector(`[data-theme="${this.currentTheme}"]`);
+        if (activeIcon) {
+          activeIcon.style.display = 'inline';
+          activeIcon.classList.add('active');
+        }
+        
+        // Update button title
+        const themeData = this.themes[this.currentTheme];
+        if (themeData) {
+          button.setAttribute('title', `Current theme: ${themeData.name}. Click to cycle themes.`);
+        }
+      }
+
+      if (select) {
+        select.value = this.currentTheme;
+      }
+    }
+
+    bindEvents() {
+      const button = document.getElementById('theme-toggle');
+      const select = document.getElementById('theme-select');
+
+      if (button) {
+        button.addEventListener('click', () => this.toggleTheme());
+      }
+
+      if (select) {
+        select.addEventListener('change', (e) => {
+          this.applyTheme(e.target.value);
+          this.updateToggleUI();
+        });
+      }
+
+      // Listen for system theme changes
+      if (this.systemThemeEnabled) {
+        try {
+          const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
+          const handleSystemThemeChange = () => {
+            if (this.currentTheme === 'auto') {
+              this.applyTheme('auto');
+            }
+          };
+          
+          // Use addEventListener if available, fallback to addListener
+          if (mediaQuery.addEventListener) {
+            mediaQuery.addEventListener('change', handleSystemThemeChange);
+          } else if (mediaQuery.addListener) {
+            mediaQuery.addListener(handleSystemThemeChange);
+          }
+        } catch (e) {
+          console.warn('ThemeManager: Unable to listen for system theme changes');
+        }
+      }
+
+      // Handle keyboard navigation
+      if (button) {
+        button.addEventListener('keydown', (e) => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            this.toggleTheme();
+          }
+        });
+      }
+    }
+  }
+
+  // Initialize theme manager when DOM is ready
+  function initTheme() {
+    if (typeof window.themeManager === 'undefined') {
+      window.themeManager = new ThemeManager();
+    }
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', initTheme);
+  } else {
+    initTheme();
+  }
+})();
+</script>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -27,6 +27,7 @@
                </svg>
             </button>
             {% include social-menu.html %}
+            {% include theme-toggle.html %}
          </div>
       </header>
       <main role="main" data-menu-container class="w-full max-w-screen-2xl mx-auto px-4 sm:px-6 lg:px-8 py-36 md:flex relative">

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -65,8 +65,8 @@
 
 .btn:hover,
 .btn:focus {
-  background-color: #F7F7F7;
-  color: #333;
+  background-color: var(--color-bg-secondary, #F7F7F7);
+  color: var(--color-text-primary, #333);
 }
  
  
@@ -74,9 +74,9 @@
 blockquote{
   font-family:Open Sans;
   font-style:italic;
-  color: #555555;
+  color: var(--color-text-secondary, #555555);
   padding:1.2em 30px 0.2em 25px;
-  border-left:8px solid #CCC ;
+  border-left:8px solid var(--color-border-secondary, #CCC);
   line-height:1.6;
   position: relative;
 }
@@ -96,7 +96,7 @@ blockquote::after{
 
 blockquote span{
   display:block;
-  color:#333333;
+  color: var(--color-text-primary, #333333);
   font-style: normal;
   font-weight: bold;
   margin-top:1em;

--- a/assets/css/themes.css
+++ b/assets/css/themes.css
@@ -1,0 +1,311 @@
+/* Theme CSS with Custom Properties for Dark/Light Mode Support */
+
+/* Base theme variables and transitions */
+:root {
+  /* Transition settings */
+  --theme-transition-duration: 0.3s;
+  --theme-transition-timing: ease-in-out;
+  
+  /* Base transition for theme-aware elements */
+  --theme-transition: 
+    background-color var(--theme-transition-duration) var(--theme-transition-timing),
+    color var(--theme-transition-duration) var(--theme-transition-timing),
+    border-color var(--theme-transition-duration) var(--theme-transition-timing),
+    box-shadow var(--theme-transition-duration) var(--theme-transition-timing);
+}
+
+/* Light theme (default) */
+:root,
+[data-theme="light"] {
+  /* Background colors */
+  --color-bg-primary: #ffffff;
+  --color-bg-secondary: #f8f9fa;
+  --color-bg-tertiary: #f1f3f4;
+  
+  /* Text colors */
+  --color-text-primary: #1e293b;
+  --color-text-secondary: #64748b;
+  --color-text-tertiary: #94a3b8;
+  --color-text-muted: #cbd5e1;
+  
+  /* Border and accent colors */
+  --color-border-primary: #e2e8f0;
+  --color-border-secondary: #cbd5e1;
+  --color-accent-primary: #8b5cf6;
+  --color-accent-hover: #7c3aed;
+  
+  /* Component-specific colors */
+  --color-header-bg: #ffffff;
+  --color-header-text: #1e293b;
+  --color-header-border: rgba(0, 0, 0, 0.1);
+  --color-sidebar-bg: #ffffff;
+  --color-sidebar-text: #1e293b;
+  --color-code-bg: #f1f5f9;
+  --color-code-text: #334155;
+}
+
+/* Dark theme */
+[data-theme="dark"] {
+  /* Background colors */
+  --color-bg-primary: #0f172a;
+  --color-bg-secondary: #1e293b;
+  --color-bg-tertiary: #334155;
+  
+  /* Text colors */
+  --color-text-primary: #f8fafc;
+  --color-text-secondary: #cbd5e1;
+  --color-text-tertiary: #94a3b8;
+  --color-text-muted: #64748b;
+  
+  /* Border and accent colors */
+  --color-border-primary: #334155;
+  --color-border-secondary: #475569;
+  --color-accent-primary: #a78bfa;
+  --color-accent-hover: #8b5cf6;
+  
+  /* Component-specific colors */
+  --color-header-bg: #1e293b;
+  --color-header-text: #f8fafc;
+  --color-header-border: rgba(255, 255, 255, 0.1);
+  --color-sidebar-bg: #1e293b;
+  --color-sidebar-text: #f8fafc;
+  --color-code-bg: #334155;
+  --color-code-text: #e2e8f0;
+}
+
+/* Auto theme (follows system preference) */
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme="light"]) {
+    /* Background colors */
+    --color-bg-primary: #0f172a;
+    --color-bg-secondary: #1e293b;
+    --color-bg-tertiary: #334155;
+    
+    /* Text colors */
+    --color-text-primary: #f8fafc;
+    --color-text-secondary: #cbd5e1;
+    --color-text-tertiary: #94a3b8;
+    --color-text-muted: #64748b;
+    
+    /* Border and accent colors */
+    --color-border-primary: #334155;
+    --color-border-secondary: #475569;
+    --color-accent-primary: #a78bfa;
+    --color-accent-hover: #8b5cf6;
+    
+    /* Component-specific colors */
+    --color-header-bg: #1e293b;
+    --color-header-text: #f8fafc;
+    --color-header-border: rgba(255, 255, 255, 0.1);
+    --color-sidebar-bg: #1e293b;
+    --color-sidebar-text: #f8fafc;
+    --color-code-bg: #334155;
+    --color-code-text: #e2e8f0;
+  }
+}
+
+/* Theme-aware component styling */
+
+/* Apply theme transitions to key elements */
+body,
+header,
+main,
+nav,
+article,
+aside,
+.docs,
+.docs-left-sidebar,
+.docs-right-sidebar {
+  transition: var(--theme-transition);
+}
+
+/* Override existing Tailwind classes with CSS variables */
+
+/* Body and main containers */
+.docs {
+  background-color: var(--color-bg-primary) !important;
+  color: var(--color-text-secondary) !important;
+}
+
+/* Header styling */
+header[role="banner"] {
+  background-color: var(--color-header-bg) !important;
+  border-bottom-color: var(--color-header-border) !important;
+  color: var(--color-header-text) !important;
+}
+
+/* Navigation text */
+.text-navy {
+  color: var(--color-header-text) !important;
+}
+
+/* Page titles */
+.text-navy.leading-tight {
+  color: var(--color-text-primary) !important;
+}
+
+/* Main content text */
+.text-gray-500 {
+  color: var(--color-text-secondary) !important;
+}
+
+.text-gray-600 {
+  color: var(--color-text-secondary) !important;
+}
+
+.text-gray-400 {
+  color: var(--color-text-tertiary) !important;
+}
+
+/* Sidebar styling */
+.docs-left-sidebar,
+.docs-right-sidebar {
+  background-color: var(--color-sidebar-bg) !important;
+  color: var(--color-sidebar-text) !important;
+}
+
+.bg-white {
+  background-color: var(--color-bg-primary) !important;
+}
+
+/* Link styling */
+a {
+  color: var(--color-accent-primary);
+  transition: color var(--theme-transition-duration) var(--theme-transition-timing);
+}
+
+a:hover,
+a:focus {
+  color: var(--color-accent-hover);
+}
+
+/* Accent colors for interactive elements */
+.text-violet-500,
+.text-violet-600 {
+  color: var(--color-accent-primary) !important;
+}
+
+.hover\:text-violet-600:hover {
+  color: var(--color-accent-hover) !important;
+}
+
+/* Code blocks and syntax highlighting */
+[class*="language-"],
+pre,
+code {
+  background-color: var(--color-code-bg) !important;
+  color: var(--color-code-text) !important;
+}
+
+/* Border styling */
+.border-black {
+  border-color: var(--color-border-primary) !important;
+}
+
+.border-b {
+  border-bottom-color: var(--color-border-primary) !important;
+}
+
+/* Search input theming */
+.DocSearch,
+.td-search-input,
+input[type="search"] {
+  background-color: var(--color-bg-secondary) !important;
+  color: var(--color-text-primary) !important;
+  border-color: var(--color-border-primary) !important;
+}
+
+.DocSearch::placeholder,
+.td-search-input::placeholder,
+input[type="search"]::placeholder {
+  color: var(--color-text-tertiary) !important;
+}
+
+/* Button theming for existing buttons */
+.btn:hover,
+.btn:focus {
+  background-color: var(--color-bg-secondary) !important;
+  color: var(--color-text-primary) !important;
+}
+
+/* Blockquote theming */
+blockquote {
+  color: var(--color-text-secondary) !important;
+  border-left-color: var(--color-border-secondary) !important;
+}
+
+blockquote span {
+  color: var(--color-text-primary) !important;
+}
+
+/* Theme toggle button styling */
+.theme-toggle {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.theme-toggle__button {
+  background: var(--color-bg-secondary);
+  border: 1px solid var(--color-border-primary);
+  border-radius: 0.5rem;
+  padding: 0.5rem;
+  cursor: pointer;
+  transition: var(--theme-transition);
+  color: var(--color-text-primary);
+  font-size: 1.1rem;
+  line-height: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 2.5rem;
+  height: 2.5rem;
+}
+
+.theme-toggle__button:hover {
+  background: var(--color-bg-tertiary);
+  border-color: var(--color-accent-primary);
+}
+
+.theme-toggle__button:focus {
+  outline: 2px solid var(--color-accent-primary);
+  outline-offset: 2px;
+}
+
+.theme-toggle__icon {
+  display: none;
+  transition: transform 0.2s ease-in-out;
+}
+
+.theme-toggle__icon.active {
+  display: inline;
+}
+
+.theme-toggle__select {
+  background: var(--color-bg-secondary);
+  border: 1px solid var(--color-border-primary);
+  border-radius: 0.375rem;
+  padding: 0.375rem 0.75rem;
+  color: var(--color-text-primary);
+  font-size: 0.875rem;
+  cursor: pointer;
+  transition: var(--theme-transition);
+}
+
+.theme-toggle__select:hover {
+  border-color: var(--color-accent-primary);
+}
+
+.theme-toggle__select:focus {
+  outline: 2px solid var(--color-accent-primary);
+  outline-offset: 2px;
+  border-color: var(--color-accent-primary);
+}
+
+/* Reduced motion preferences */
+@media (prefers-reduced-motion: reduce) {
+  * {
+    transition-duration: 0.01s !important;
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,870 @@
+{
+  "name": "b08x.github.io",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "dependencies": {
+        "postcss": "^8.5.6",
+        "postcss-cli": "^11.0.1"
+      },
+      "devDependencies": {
+        "autoprefixer": "^10.4.21",
+        "tailwindcss": "^4.1.11"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/anymatch": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "license": "ISC",
+      "dependencies": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/autoprefixer": {
+      "version": "10.4.21",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.21.tgz",
+      "integrity": "sha512-O+A6LWV5LDHSJD3LjHYoNi4VLsj/Whi7k6zG12xTYaU4cQ8oxQGckXNX8cRHK5yOZ/ppVHe0ZBXGzSV9jXdVbQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/autoprefixer"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "browserslist": "^4.24.4",
+        "caniuse-lite": "^1.0.30001702",
+        "fraction.js": "^4.3.7",
+        "normalize-range": "^0.1.2",
+        "picocolors": "^1.1.1",
+        "postcss-value-parser": "^4.2.0"
+      },
+      "bin": {
+        "autoprefixer": "bin/autoprefixer"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      },
+      "peerDependencies": {
+        "postcss": "^8.1.0"
+      }
+    },
+    "node_modules/binary-extensions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
+      "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.25.1",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.25.1.tgz",
+      "integrity": "sha512-KGj0KoOMXLpSNkkEI6Z6mShmQy0bc1I+T7K9N81k4WWMrfz+6fQ6es80B/YLAeRoKvjYE1YSHHOW1qe9xIVzHw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "caniuse-lite": "^1.0.30001726",
+        "electron-to-chromium": "^1.5.173",
+        "node-releases": "^2.0.19",
+        "update-browserslist-db": "^1.1.3"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001731",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001731.tgz",
+      "integrity": "sha512-lDdp2/wrOmTRWuoB5DpfNkC0rJDU8DqRa6nYL6HK6sytw70QMopt/NIc/9SM7ylItlBWfACXk0tEn37UWM/+mg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
+    "node_modules/chokidar": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+      "license": "MIT",
+      "dependencies": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      },
+      "engines": {
+        "node": ">= 8.10.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT"
+    },
+    "node_modules/dependency-graph": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/dependency-graph/-/dependency-graph-1.0.0.tgz",
+      "integrity": "sha512-cW3gggJ28HZ/LExwxP2B++aiKxhJXMSIt9K48FOXQkm+vuG5gyatXnLsONRJdzO/7VfjDIiaOOa/bs4l464Lwg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.194",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.194.tgz",
+      "integrity": "sha512-SdnWJwSUot04UR51I2oPD8kuP2VI37/CADR1OHsFOUzZIvfWJBO6q11k5P/uKNyTT3cdOsnyjkrZ+DDShqYqJA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/fraction.js": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.3.7.tgz",
+      "integrity": "sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "type": "patreon",
+        "url": "https://github.com/sponsors/rawify"
+      }
+    },
+    "node_modules/fs-extra": {
+      "version": "11.3.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.0.tgz",
+      "integrity": "sha512-Z4XaCL6dUDHfP/jT25jJKMmtxvuwbkrD1vNSMFlo9lNLY2c5FHYSQgHPRZUjAB26TpDEoW9HCOgplrdbaPV/ew==",
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "license": "ISC"
+    },
+    "node_modules/is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "license": "MIT",
+      "dependencies": {
+        "binary-extensions": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/jsonfile": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/lilconfig": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
+      "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antonk52"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.19",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.19.tgz",
+      "integrity": "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/normalize-range": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
+      "integrity": "sha512-bdok/XvKII3nUpklnV6P2hxtMNrCboOjAcyBuQnWEhO665FwrSNRxU+AqpsyvO6LgGYPspN+lu5CLtw4jPRKNA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pify": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.6",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
+      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/postcss-cli": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-cli/-/postcss-cli-11.0.1.tgz",
+      "integrity": "sha512-0UnkNPSayHKRe/tc2YGW6XnSqqOA9eqpiRMgRlV1S6HdGi16vwJBx7lviARzbV1HpQHqLLRH3o8vTcB0cLc+5g==",
+      "license": "MIT",
+      "dependencies": {
+        "chokidar": "^3.3.0",
+        "dependency-graph": "^1.0.0",
+        "fs-extra": "^11.0.0",
+        "picocolors": "^1.0.0",
+        "postcss-load-config": "^5.0.0",
+        "postcss-reporter": "^7.0.0",
+        "pretty-hrtime": "^1.0.3",
+        "read-cache": "^1.0.0",
+        "slash": "^5.0.0",
+        "tinyglobby": "^0.2.12",
+        "yargs": "^17.0.0"
+      },
+      "bin": {
+        "postcss": "index.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "postcss": "^8.0.0"
+      }
+    },
+    "node_modules/postcss-load-config": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-5.1.0.tgz",
+      "integrity": "sha512-G5AJ+IX0aD0dygOE0yFZQ/huFFMSNneyfp0e3/bT05a8OfPC5FUoZRPfGijUdGOJNMewJiwzcHJXFafFzeKFVA==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "lilconfig": "^3.1.1",
+        "yaml": "^2.4.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "jiti": ">=1.21.0",
+        "postcss": ">=8.0.9",
+        "tsx": "^4.8.1"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        },
+        "postcss": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/postcss-reporter": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-reporter/-/postcss-reporter-7.1.0.tgz",
+      "integrity": "sha512-/eoEylGWyy6/DOiMP5lmFRdmDKThqgn7D6hP2dXKJI/0rJSO1ADFNngZfDzxL0YAxFvws+Rtpuji1YIHj4mySA==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "picocolors": "^1.0.0",
+        "thenby": "^1.3.4"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "postcss": "^8.1.0"
+      }
+    },
+    "node_modules/postcss-value-parser": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pretty-hrtime": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz",
+      "integrity": "sha512-66hKPCr+72mlfiSjlEB1+45IjXSqvVAIy6mocupoww4tBFE9R9IhwwUGoI4G++Tc9Aq+2rxOt0RFU6gPcrte0A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/read-cache": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
+      "integrity": "sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==",
+      "license": "MIT",
+      "dependencies": {
+        "pify": "^2.3.0"
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "license": "MIT",
+      "dependencies": {
+        "picomatch": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8.10.0"
+      }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/slash": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-5.1.0.tgz",
+      "integrity": "sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/tailwindcss": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.11.tgz",
+      "integrity": "sha512-2E9TBm6MDD/xKYe+dvJZAmg3yxIEDNRc0jwlNyDg/4Fil2QcSLjFKGVff0lAf1jjeaArlG/M75Ey/EYr/OJtBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/thenby": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/thenby/-/thenby-1.3.4.tgz",
+      "integrity": "sha512-89Gi5raiWA3QZ4b2ePcEwswC3me9JIg+ToSgtE0JWeCynLnLxNr/f9G+xfo9K+Oj4AFdom8YNJjibIARTJmapQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.14",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.14.tgz",
+      "integrity": "sha512-tX5e7OM1HnYr2+a2C/4V0htOcSQcoSTH9KgJnVvNm5zm/cyEWKJ7j7YutsH9CxMdtOkkLFy2AHrMci9IM8IPZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.4.4",
+        "picomatch": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyglobby/node_modules/fdir": {
+      "version": "6.4.6",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.6.tgz",
+      "integrity": "sha512-hiFoqpyZcfNm1yc4u8oWCf9A2c4D3QjCrks3zmoVKVxpQRzmPNar1hUJcBG2RQHvEVGDN+Jm81ZheVLAQMK6+w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tinyglobby/node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.3.tgz",
+      "integrity": "sha512-UxhIZQ+QInVdunkDAaiazvvT/+fXL5Osr0JZlJulepYu6Jd7qJtDZjlur0emRlT71EN3ScPoE7gvsuIKKNavKw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yaml": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.0.tgz",
+      "integrity": "sha512-4lLa/EcQCB0cJkyts+FpIRx5G/llPxfP6VQU5KByHEhLxY3IJCH0f0Hy1MHI8sClTvsIb8qwRJ6R/ZdlDJ/leQ==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,10 @@
+{
+  "dependencies": {
+    "postcss": "^8.5.6",
+    "postcss-cli": "^11.0.1"
+  },
+  "devDependencies": {
+    "autoprefixer": "^10.4.21",
+    "tailwindcss": "^4.1.11"
+  }
+}

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,9 @@
+module.exports = {
+  plugins: [
+    require('tailwindcss'),
+    require('autoprefixer'),
+    ...(process.env.JEKYLL_ENV == 'production'
+      ? [require('cssnano')({ preset: 'default' })]
+      : [])
+  ]
+}


### PR DESCRIPTION
This commit introduces a new theme toggling feature, allowing users to switch between different visual themes.

Key changes include:
- A new `_includes/theme-toggle.html` partial for the UI switch.
- A `_data/theme.yml` file to define available themes and their settings.
- New CSS styles in `assets/css/themes.css` to support multiple themes.
- Integration of PostCSS and Tailwind CSS for advanced styling capabilities, reflected in `package.json` and `postcss.config.js`.
- Updates to `_config.yml`, `_includes/head.html`, and `_layouts/default.html` to load and manage theme assets and settings.
- The CI/CD pipeline in `.github/workflows/jekyll.yml` is updated to accommodate the new build process.